### PR TITLE
Adds a queue page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile-frontend
     depends_on:
+      - mongo
       - redis
       - celery
     command: gunicorn -k gevent -b 0.0.0.0:5002 xssp_api.application:app
@@ -22,6 +23,7 @@ services:
       context: .
       dockerfile: Dockerfile-celery
     depends_on:
+      - mongo
       - rabbitmq
       - redis
     command: celery -A xssp_api.application:celery worker -B -n xssp.%n
@@ -37,6 +39,9 @@ services:
 
   rabbitmq:
     image: rabbitmq
+
+  mongo:
+    image: mongo
 
   data:
     image: tianon/true

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ requests==2.3.0
 six==1.8.0
 watchdog==0.8.3
 wsgiref==0.1.2
+pymongo==3.3.0

--- a/xssp_api/default_settings.py
+++ b/xssp_api/default_settings.py
@@ -23,3 +23,7 @@ DSSP_REDO_ROOT = '/mnt/cmbi4/dssp_redo/'
 HSSP_ROOT = '/mnt/cmbi4/hssp/'
 HG_HSSP_ROOT = '/mnt/cmbi4/hg-hssp'
 HSSP_STO_ROOT = '/mnt/cmbi4/hssp3/'
+
+# Database
+MONGODB_URI = 'mongodb://xsspapi_mongo_1'
+MONGODB_DB_NAME = 'xsspapi'

--- a/xssp_api/factory.py
+++ b/xssp_api/factory.py
@@ -111,6 +111,12 @@ def create_app(settings=None):
     app.register_blueprint(api_bp)
     app.register_blueprint(dashboard_bp)
 
+    # Database
+    from xssp_api.storage import storage
+    storage.uri = app.config['MONGODB_URI']
+    storage.db_name = app.config['MONGODB_DB_NAME']
+    storage.connect()
+
     return app
 
 

--- a/xssp_api/frontend/api/endpoints.py
+++ b/xssp_api/frontend/api/endpoints.py
@@ -7,7 +7,7 @@ from flask.json import jsonify
 
 from xssp_api.frontend.dashboard.forms import XsspForm
 from xssp_api.services.xssp import process_request
-
+from xssp_api.storage import storage
 
 _log = logging.getLogger(__name__)
 
@@ -110,3 +110,10 @@ def api_doc():
 @bp.route('/examples', methods=['GET'])
 def api_examples():
     return render_template('api/examples.html')  # pragma: no cover
+
+
+@bp.route('/queued/', methods=['GET'])
+def get_queued():
+    res = storage.find('tasks', {})
+    task_ids = map(lambda t: t['task_id'], res)
+    return jsonify({ 'tasks': task_ids })

--- a/xssp_api/frontend/dashboard/views.py
+++ b/xssp_api/frontend/dashboard/views.py
@@ -38,6 +38,11 @@ def output(input_type, output_type, celery_id):
                            celery_id=celery_id)
 
 
+@bp.route("/queue/", methods=['GET'])
+def queue():
+    return render_template("dashboard/queue.html")
+
+
 @bp.errorhandler(Exception)
 def exception_error_handler(error):  # pragma: no cover
     _log.error("Unhandled exception: {}".format(error))

--- a/xssp_api/frontend/templates/dashboard/queue.html
+++ b/xssp_api/frontend/templates/dashboard/queue.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="col-sm-2">Task ID</th>
+      <th class="col-sm-4">Input Type</th>
+      <th class="col-sm-4">Output Type</th>
+      <th class="col-sm-2">Status</th>
+    </tr>
+  </thead>
+  <tbody id="queue">
+  </tbody>
+</table>
+{% endblock %}
+
+{% block js %}
+<script type="text/javascript">
+  var intervalId = setInterval(update_queue, 1000);
+
+  function update_queue() {
+    $.getJSON(
+      "{{ url_for('xssp.get_queued') }}",
+      function(data) {
+        $("#queue").empty();
+        for (var i = 0; i < data.tasks.length; i++) {
+
+          var task = data.tasks[i];
+          $("#queue").append("<tr><td>" + task.task_id + "</td>" +
+                             "<td>" + task.input_type + "</td>" +
+                             "<td>" + task.output_type + "</td>" +
+                             "<td>" + task.status + "</td></tr>");
+        }
+      }
+    );
+  }
+</script>
+{% endblock %}

--- a/xssp_api/frontend/templates/dashboard/queue.html
+++ b/xssp_api/frontend/templates/dashboard/queue.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
 
 {% block content %}
-<table class="table table-bordered">
+<table class="table table-bordered table-hover">
   <thead>
     <tr>
       <th class="col-sm-2">Task ID</th>
-      <th class="col-sm-4">Input Type</th>
-      <th class="col-sm-4">Output Type</th>
-      <th class="col-sm-2">Status</th>
+      <th class="col-sm-1">Input Type</th>
+      <th class="col-sm-1">Output Type</th>
+      <th class="col-sm-1">Status</th>
+      <th class="col-sm-1"></th>
     </tr>
   </thead>
   <tbody id="queue">
@@ -25,12 +26,19 @@
       function(data) {
         $("#queue").empty();
         for (var i = 0; i < data.tasks.length; i++) {
-
           var task = data.tasks[i];
-          $("#queue").append("<tr><td>" + task.task_id + "</td>" +
+          var output_url = "{{ url_for('dashboard.output', input_type='input_type', output_type='output_type', celery_id='celery_id') }}";
+          output_url = output_url.replace('input_type', task.input_type)
+                                 .replace('output_type', task.output_type)
+                                 .replace('celery_id', task.task_id);
+
+          $("#queue").append("<a href=\"" + output_url + "\">" +
+                             "<tr><td>" + task.task_id + "</td>" +
                              "<td>" + task.input_type + "</td>" +
                              "<td>" + task.output_type + "</td>" +
-                             "<td>" + task.status + "</td></tr>");
+                             "<td>" + task.status + "</td>" +
+                             "<td><a href=\"" + output_url + "\">" + 
+                             "<span class=\"glyphicon glyphicon-circle-arrow-right\"></span></a></td></tr>");
         }
       }
     );

--- a/xssp_api/frontend/templates/dashboard/queue.html
+++ b/xssp_api/frontend/templates/dashboard/queue.html
@@ -1,45 +1,100 @@
 {% extends "base.html" %}
 
 {% block content %}
-<table class="table table-bordered table-hover">
-  <thead>
-    <tr>
-      <th class="col-sm-2">Task ID</th>
-      <th class="col-sm-1">Input Type</th>
-      <th class="col-sm-1">Output Type</th>
-      <th class="col-sm-1">Status</th>
-      <th class="col-sm-1"></th>
-    </tr>
-  </thead>
-  <tbody id="queue">
-  </tbody>
-</table>
+<div class="panel panel-default">
+  <table class="table table-bordered table-hover">
+    <thead>
+      <tr>
+        <th class="col-sm-2">Task ID</th>
+        <th class="col-sm-1">Input Type</th>
+        <th class="col-sm-1">Output Type</th>
+        <th class="col-sm-1">Status</th>
+        <th class="col-sm-1"></th>
+      </tr>
+    </thead>
+    <tbody id="queue">
+    </tbody>
+  </table>
+  <div class="panel-footer">
+    <ul class="pagination" id="pagination-footer">
+    </ul>
+  </div>
+</div>
 {% endblock %}
 
 {% block js %}
 <script type="text/javascript">
   var intervalId = setInterval(update_queue, 1000);
 
+  var task_queue = [];
+  var pagination_index = 0,
+      max_per_page = 10,
+      max_buttons = 3;
+
+  function pagination_goto(index) {
+    pagination_index = index;
+    adjust_pagination();
+  }
+
+  function adjust_pagination() {
+    $("#queue").empty();
+    $("#pagination-footer").empty();
+
+    // Fill up the page:
+    for (var i = pagination_index * max_per_page;
+         i < task_queue.length && i < ((pagination_index + 1) * max_per_page);
+         i++) {
+      var task = task_queue[i];
+      var output_url = "{{ url_for('dashboard.output', input_type='input_type', output_type='output_type', celery_id='celery_id') }}";
+      output_url = output_url.replace('input_type', task.input_type)
+                             .replace('output_type', task.output_type)
+                             .replace('celery_id', task.task_id);
+
+      $("#queue").append("<a href=\"" + output_url + "\">" +
+                         "<tr><td>" + task.task_id + "</td>" +
+                         "<td>" + task.input_type + "</td>" +
+                         "<td>" + task.output_type + "</td>" +
+                         "<td>" + task.status + "</td>" +
+                         "<td><a href=\"" + output_url + "\">" +
+                         "<span class=\"glyphicon glyphicon-circle-arrow-right\"></span></a></td></tr>");
+    }
+
+    // Fill up the pagination footer with links:
+    if (pagination_index > 0)
+      $("#pagination-footer").append("<li class=\"previous\"><a onclick=\"pagination_goto(0);\">&lt;&lt;</a></li>");
+    else
+      $("#pagination-footer").append("<li class=\"previous disabled unavailable\"><a>&lt;&lt;</a></li>");
+
+    for (var i = 0; i < task_queue.length; i += max_per_page) {
+      var n = i / max_per_page;
+
+      if (n >= max_buttons) {
+        // Too many pages, skip to the end:
+        $("#pagination-footer").append("<li class=\"disabled unavailable\"><a>...</a></li>")
+        i = task_queue.length - max_buttons * max_per_page;
+        continue;
+      }
+
+      if (pagination_index != n)
+        $("#pagination-footer").append("<li><a onclick=\"pagination_goto(" + n + ");\">" + (n + 1) + "</a></li>")
+      else
+        $("#pagination-footer").append("<li class=\"active\"><a>" + (n + 1) + "</a></li>")
+    }
+
+    var last_page_index = Math.ceil(task_queue.length / max_per_page) - 1;
+    if (pagination_index < last_page_index)
+      $("#pagination-footer").append("<li class=\"next\"><a onclick=\"pagination_goto(" + last_page_index + ");\">&gt;&gt;</a></li>");
+    else
+      $("#pagination-footer").append("<li class=\"next disabled unavailable\"><a>&gt;&gt;</a></li>");
+  }
+
   function update_queue() {
     $.getJSON(
       "{{ url_for('xssp.get_queued') }}",
       function(data) {
-        $("#queue").empty();
-        for (var i = 0; i < data.tasks.length; i++) {
-          var task = data.tasks[i];
-          var output_url = "{{ url_for('dashboard.output', input_type='input_type', output_type='output_type', celery_id='celery_id') }}";
-          output_url = output_url.replace('input_type', task.input_type)
-                                 .replace('output_type', task.output_type)
-                                 .replace('celery_id', task.task_id);
+        task_queue = data.tasks;
 
-          $("#queue").append("<a href=\"" + output_url + "\">" +
-                             "<tr><td>" + task.task_id + "</td>" +
-                             "<td>" + task.input_type + "</td>" +
-                             "<td>" + task.output_type + "</td>" +
-                             "<td>" + task.status + "</td>" +
-                             "<td><a href=\"" + output_url + "\">" + 
-                             "<span class=\"glyphicon glyphicon-circle-arrow-right\"></span></a></td></tr>");
-        }
+        adjust_pagination();
       }
     );
   }

--- a/xssp_api/storage.py
+++ b/xssp_api/storage.py
@@ -1,0 +1,89 @@
+import logging
+
+from pymongo import MongoClient, ASCENDING
+
+
+_log = logging.getLogger(__name__)
+
+
+class Storage(object):
+    def __init__(self, uri=None, db_name=None):
+        self._db = None
+        self._db_name = db_name
+        self._client = None
+        self._uri = uri
+
+        if self._uri is not None and self._db_name is not None:
+            self.connect()
+            assert self._db is not None
+
+    @property
+    def db(self):
+        if self._db is None:
+            self.connect()
+            assert self._db is not None
+        return self._db
+
+    @property
+    def db_name(self):
+        return self._db_name
+
+    @db_name.setter
+    def db_name(self, db_name):
+        self._db_name = db_name
+
+    @property
+    def uri(self):
+        return self._uri
+
+    @uri.setter
+    def uri(self, uri):
+        self._uri = uri
+
+    def connect(self):
+        if self.uri is None or self._db_name is None:
+            raise Exception("Storage hasn't been configured")
+
+        _log.info("Connecting to '{}'".format(self.uri))
+        self._client = MongoClient(self._uri)
+        assert self._client is not None
+        self._db = self._client[self._db_name]
+        assert self._db is not None
+
+        self.db['tasks'].create_index([('task_id', ASCENDING)])
+
+    def insert(self, collection, documents):
+        if self._db is None:
+            raise Exception("Not connected to storage. Did you call connect()?")
+
+        if len(documents) == 0:
+            raise ValueError("Document list is empty. Nothing to insert.")
+
+        _log.info("Inserting {} documents into '{}'".format(len(documents),
+                                                            collection))
+        return self._db[collection].insert(documents)
+
+    def remove(self, collection, spec_or_id=None):
+        if self._db is None:
+            raise Exception("Not connected to storage. Did you call connect()?")
+
+        _log.info("Removing documents from '{}'".format(collection))
+        return self._db[collection].remove(spec_or_id)
+
+    def find(self, collection, selector):
+        if self._db is None:
+            raise Exception("Not connected to storage. Did you call connect()?")
+
+        _log.info("Querying documents in '{}'".format(collection))
+        cursor = self._db[collection].find(selector)
+        return [d for d in cursor]
+
+    def find_one(self, collection, selector):
+        if self._db is None:
+            raise Exception("Not connected to storage. Did you call connect()?")
+
+        _log.info("Querying single document in '{}'".format(collection))
+        return self._db[collection].find_one(selector)
+
+
+storage = Storage()

--- a/xssp_api/tasks.py
+++ b/xssp_api/tasks.py
@@ -13,19 +13,8 @@ from celery.signals import setup_logging, task_prerun
 from flask import current_app as flask_app
 
 from xssp_api.frontend.validators import RE_FASTA_DESCRIPTION
-from xssp_api.storage import storage
 
 _log = logging.getLogger(__name__)
-
-
-@task_prerun.connect
-def task_prerun_handler(task_id, task, *args, **kwargs):
-    task_object = {'task_id': task_id}
-
-    _log.debug('task object is {}'.format(task_object))
-
-    # Put the task id in the database so the status can be retrieved later
-    storage.insert('tasks', task_object)
 
 
 @setup_logging.connect

--- a/xssp_api/tasks.py
+++ b/xssp_api/tasks.py
@@ -9,13 +9,23 @@ import textwrap
 import uuid
 
 from celery import current_app as celery_app
-from celery.signals import setup_logging
+from celery.signals import setup_logging, task_prerun
 from flask import current_app as flask_app
 
 from xssp_api.frontend.validators import RE_FASTA_DESCRIPTION
-
+from xssp_api.storage import storage
 
 _log = logging.getLogger(__name__)
+
+
+@task_prerun.connect
+def task_prerun_handler(task_id, task, *args, **kwargs):
+    task_object = {'task_id': task_id}
+
+    _log.debug('task object is {}'.format(task_object))
+
+    # Put the task id in the database so the status can be retrieved later
+    storage.insert('tasks', task_object)
 
 
 @setup_logging.connect


### PR DESCRIPTION
The queue page is accessible under "/queue". There is no link to it. (yet)

Mongo is used to store all job ids, together with the submitted input and output types.
A javascript runs on the queue page to retrieve this information and show it in form of pagination.